### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/lib/console.dart
+++ b/lib/console.dart
@@ -108,7 +108,7 @@ class ConsoleClient implements Client {
       await stream.pipe(rq);
     } else if (body is io.File) {
       applyContentLength(await body.length());
-      await body.openRead().pipe(rq);
+      await body.openRead().cast<List<int>>().pipe(rq);
     } else if (body == null) {
       await rq.close();
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: http_client
 description: |
     A platform-independent HTTP client API supporting browser, console, and curl (for SOCKS proxy).
-version: 1.0.4
+version: 1.0.4+1
 author: Istvan Soos <istvan.soos@gmail.com>
 
 homepage: https://github.com/isoos/http_client


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900