### PR TITLE
Add POST Support to Curl Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.1+1
+
+- Support POST method in `CurlClient`. ([#9](https://github.com/isoos/http_client/pull/9) by [rbandres98](https://github.com/rbandres98))
+
 ## 1.4.1
 
 - Support all SOCKS type with `curl`. ([#6](https://github.com/isoos/http_client/pull/6) by [utopicnarwhal](https://github.com/utopicnarwhal))

--- a/lib/curl.dart
+++ b/lib/curl.dart
@@ -80,6 +80,9 @@ class CurlClient implements Client {
     }
     args.addAll(['-X', method.toUpperCase()]);
     // --data parameter added in GET and POST Method. If method is 'GET', body may no have any effect in the request. UTF-8 encoding setted as default.
+    if(request.body is! List<int>){
+      throw Exception('Request body type must be List<int>');
+    }
     if (request.body != null) args.addAll(['--data', utf8.decode(request.body)]);
     args.add(request.uri.toString());
     // TODO: handle status code and reason phrase

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: http_client
 description: |
     A platform-independent HTTP client API supporting browser, console, and curl (for SOCKS proxy).
-version: 1.4.1
+version: 1.4.1+1
 
 homepage: https://github.com/isoos/http_client
 


### PR DESCRIPTION
I am making my first pull request to add support to POST method using CURL. This allows to add basic String value or Json String value to the request as -d or --data parameter. I will add more methods and features as soon as possible. 

* Headers are not supported yet.
* If method is 'GET', body may no have any effect in the request.
* UTF-8 encoding setted as default.
* This PR fixes or closes issue: fixes #8

## Post Test
I'm using this feature for a personal project and testing this feature I got a successful result.

### Code used to make request:
```dart
final client = CurlClient();
final rs = await client.send(Request('POST', 'http://192.168.4.1:6104/', body: jsonTemplate));
if(rs.statusCode == 200){
  final textContent = await rs.readAsString();
  print(textContent);
}
```

### 	Data used in jsonTemplate variable:
```dart
jsonTemplate = "{"ap":{"ssid":"NetworkSSID","password":"NetworkPass","ip":"192.168.4.1","netmask":"255.255.255.0","gateway":"192.168.4.1"},"station":{"ssid":"MainNetSSID","password":"MainNetPass","enable":"true","status":0}}";
```

### Received response
![image](https://user-images.githubusercontent.com/29277715/103816896-b5e26780-5033-11eb-95ee-00b59fe344e2.png)
